### PR TITLE
Homepage update

### DIFF
--- a/src/screens/Home.jsx
+++ b/src/screens/Home.jsx
@@ -51,6 +51,17 @@ const MobileHeaderContainer = styled.div`
   }
 `
 
+const SubheadingContainer = styled.div`
+  font-size: 16px;
+  text-align: center;
+  margin: 10px 0 20px 0;
+`
+
+const MobileSubheadingContainer = styled.div`
+  font-size: 14px;
+  margin: 10px 0 20px 0;
+`
+
 const NavContainer = styled.nav`
   display: flex;
   flex-direction: column;
@@ -128,6 +139,10 @@ const MobileNavigationCard = styled.section`
 
 const Emphasis = styled.span`
   color: orange;
+`
+
+const EmphasisSmallSpace = styled.span`
+  font-size: 5px;
 `
 
 const AuthContainer = styled.div`
@@ -212,6 +227,9 @@ const Home = props => (
       <MobileHeaderContainer>
         <h1>Thomas Fire Help</h1>
       </MobileHeaderContainer>
+      <MobileSubheadingContainer>
+        <h3> We're grassroots volunteers connecting help with need to recover from the Thomas Fire. Our community-sourced listings include: Housing, Supplies, Clothing, Volunteers, Animal Needs, Free Food, and Services.</h3>
+      </MobileSubheadingContainer>
       <MobileNavContainer>
         <StyledLink to="/looking_for_resources">
           <MobileNavigationCard>
@@ -226,7 +244,14 @@ const Home = props => (
       </MobileNavContainer>
       <MobileNotificationBar>
         <div>
-          In event of Emergency, call <a href="tel:911"><Emphasis>911</Emphasis></a>
+          Homegrown in Ventura County 🌱
+        </div>
+        <div>
+          Part of the
+            <Emphasis> #805
+              <EmphasisSmallSpace> </EmphasisSmallSpace>
+              Strong
+            </Emphasis> Network
         </div>
         <div>
           <a href="mailto:help@thomasfirehelp.com">Send us Feedback 💌</a>
@@ -243,6 +268,10 @@ const Home = props => (
       <HeaderContainer>
         <h1>Thomas Fire Help</h1>
       </HeaderContainer>
+      <SubheadingContainer>
+        <h3>We're grassroots volunteers connecting help with need to recover from the Thomas Fire.</h3>
+        <h3>Our community-sourced listings include: Housing, Supplies, Clothing, Volunteers, Animal Needs, Free Food, and Services.</h3>
+      </SubheadingContainer>
       <NavContainer>
         <StyledLink to="/looking_for_resources">
           <NavigationCard>
@@ -257,7 +286,14 @@ const Home = props => (
       </NavContainer>
       <NotificationBar>
         <div>
-          In event of Emergency, call <a href="tel:911"><Emphasis>911</Emphasis></a>
+          <h3>Homegrown in Ventura County 🌱</h3>
+        </div>
+        <div>
+          <h3>Part of the
+            <Emphasis> #805
+              <EmphasisSmallSpace> </EmphasisSmallSpace>
+              Strong
+            </Emphasis> Network</h3>
         </div>
         <div>
           <a href="mailto:help@thomasfirehelp.com">Send us Feedback 💌</a>

--- a/src/screens/Home.jsx
+++ b/src/screens/Home.jsx
@@ -148,10 +148,6 @@ const MobileNavigationCard = styled.section`
     box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.23), 0 3px 6px 0 rgba(0, 0, 0, 0.16);
   }
 `
-const MobileNavigationCardSubheading = styled.div`
-  font-size: 12px;
-  padding: 4px 4px;
-`
 
 const Emphasis = styled.span`
   color: orange;
@@ -246,10 +242,7 @@ const Home = props => (
       <MobileNavContainer>
         <StyledLink to="/looking_for_resources">
           <MobileNavigationCard>
-            Show me resources
-            {/* <MobileNavigationCardSubheading>
-            Housing, Services, Free Food, Animal Needs, Supplies, Clothing & Volunteers
-            </MobileNavigationCardSubheading> */}
+            View recovery resources
           </MobileNavigationCard>
         </StyledLink>
         <StyledLink to="/helping">
@@ -290,7 +283,7 @@ const Home = props => (
       <NavContainer>
         <StyledLink to="/looking_for_resources">
           <NavigationCard>
-            Show me resources
+            View recovery resources
           </NavigationCard>
         </StyledLink>
         <StyledLink to="/helping">
@@ -300,8 +293,7 @@ const Home = props => (
         </StyledLink>
       </NavContainer>
       <SubheadingContainer>
-        <h3>We're grassroots volunteers connecting help with need to recover from the Thomas Fire.</h3>
-        <h3>Our community-sourced listings include: Housing, Services, Free Food, Animal Needs, Supplies, Clothing and Volunteers</h3>
+        <h3>We're volunteers connecting community-sourced help to recovery needs for the Thomas Fire.</h3>
       </SubheadingContainer>
       <NotificationBar>
         <div>

--- a/src/screens/Home.jsx
+++ b/src/screens/Home.jsx
@@ -55,12 +55,21 @@ const MobileHeaderContainer = styled.div`
 const SubheadingContainer = styled.div`
   font-size: 16px;
   text-align: center;
-  margin: 10px 0 20px 0;
+  width: 450px;
+  padding: 30px 0px;
+  margin: 20px 0 10px 0;
+  animation: ${fadeIn} 1.5s forwards;
+  animation-delay: .3s;
+  margin-bottom: 10px;
 `
 
 const MobileSubheadingContainer = styled.div`
   font-size: 14px;
-  margin: 10px 0 20px 0;
+  margin: 10px 0 5px 0;
+  animation: ${fadeIn} 1.5s forwards;
+  animation-delay: .3s;
+  margin-bottom: 10px;
+  
 `
 
 const NavContainer = styled.nav`
@@ -191,7 +200,7 @@ const NotificationBar = styled.div`
   opacity: 0;
   animation: ${fadeIn} 1.5s forwards;
   animation-delay: .7s;
-  margin: 50px 0px 30px 0px;
+  margin: 30px 0px 20px 0px;
 `
 
 const Footer = styled.footer`
@@ -212,8 +221,8 @@ const MobileFooter = styled.footer`
   flex: 1;
   font-size: 28px;
   text-align: left;
-  margin: 0px 10px;
-  padding-top: 6px;
+  margin: 15px 0px 10px 0px;
+  padding-top: 10px;
   p {
     font-size: 12px;
   }
@@ -228,9 +237,6 @@ const Home = props => (
       <MobileHeaderContainer>
         <h1>Thomas Fire Help</h1>
       </MobileHeaderContainer>
-      <MobileSubheadingContainer>
-        <h3> We're grassroots volunteers connecting help with need to recover from the Thomas Fire. Our community-sourced listings include: Housing, Services, Free Food, Animal Needs, Supplies, Clothing and Volunteers</h3>
-      </MobileSubheadingContainer>
       <MobileNavContainer>
         <StyledLink to="/looking_for_resources">
           <MobileNavigationCard>
@@ -243,6 +249,9 @@ const Home = props => (
           </MobileNavigationCard>
         </StyledLink>
       </MobileNavContainer>
+      <MobileSubheadingContainer>
+        <h3> We're grassroots volunteers connecting help with need to recover from the Thomas Fire. Our community-sourced listings include: Housing, Services, Free Food, Animal Needs, Supplies, Clothing and Volunteers</h3>
+      </MobileSubheadingContainer>
       <MobileNotificationBar>
         <div>
           Homegrown in Ventura County 🌱
@@ -269,10 +278,6 @@ const Home = props => (
       <HeaderContainer>
         <h1>Thomas Fire Help</h1>
       </HeaderContainer>
-      <SubheadingContainer>
-        <h3>We're grassroots volunteers connecting help with need to recover from the Thomas Fire.</h3>
-        <h3>Our community-sourced listings include: Housing, Services, Free Food, Animal Needs, Supplies, Clothing and Volunteers</h3>
-      </SubheadingContainer>
       <NavContainer>
         <StyledLink to="/looking_for_resources">
           <NavigationCard>
@@ -285,6 +290,10 @@ const Home = props => (
           </NavigationCard>
         </StyledLink>
       </NavContainer>
+      <SubheadingContainer>
+        <h3>We're grassroots volunteers connecting help with need to recover from the Thomas Fire.</h3>
+        <h3>Our community-sourced listings include: Housing, Services, Free Food, Animal Needs, Supplies, Clothing and Volunteers</h3>
+      </SubheadingContainer>
       <NotificationBar>
         <div>
           <h3>Homegrown in Ventura County 🌱</h3>

--- a/src/screens/Home.jsx
+++ b/src/screens/Home.jsx
@@ -65,6 +65,7 @@ const SubheadingContainer = styled.div`
 
 const MobileSubheadingContainer = styled.div`
   font-size: 14px;
+  text-align: center;
   margin: 10px 0 5px 0;
   animation: ${fadeIn} 1.5s forwards;
   animation-delay: .3s;
@@ -151,8 +152,6 @@ const MobileNavigationCardSubheading = styled.div`
   font-size: 12px;
   padding: 4px 4px;
 `
-
-
 
 const Emphasis = styled.span`
   color: orange;

--- a/src/screens/Home.jsx
+++ b/src/screens/Home.jsx
@@ -129,6 +129,7 @@ const NavigationCard = styled.section`
 
 const MobileNavigationCard = styled.section`
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   margin-top: 20px;
@@ -146,6 +147,12 @@ const MobileNavigationCard = styled.section`
     box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.23), 0 3px 6px 0 rgba(0, 0, 0, 0.16);
   }
 `
+const MobileNavigationCardSubheading = styled.div`
+  font-size: 12px;
+  padding: 4px 4px;
+`
+
+
 
 const Emphasis = styled.span`
   color: orange;
@@ -241,6 +248,9 @@ const Home = props => (
         <StyledLink to="/looking_for_resources">
           <MobileNavigationCard>
             Show me resources
+            {/* <MobileNavigationCardSubheading>
+            Housing, Services, Free Food, Animal Needs, Supplies, Clothing & Volunteers
+            </MobileNavigationCardSubheading> */}
           </MobileNavigationCard>
         </StyledLink>
         <StyledLink to="/helping">
@@ -250,7 +260,7 @@ const Home = props => (
         </StyledLink>
       </MobileNavContainer>
       <MobileSubheadingContainer>
-        <h3> We're grassroots volunteers connecting help with need to recover from the Thomas Fire. Our community-sourced listings include: Housing, Services, Free Food, Animal Needs, Supplies, Clothing and Volunteers</h3>
+        <h3>We're volunteers connecting community-sourced help to recovery needs for the Thomas Fire.</h3>
       </MobileSubheadingContainer>
       <MobileNotificationBar>
         <div>

--- a/src/screens/Home.jsx
+++ b/src/screens/Home.jsx
@@ -11,6 +11,7 @@ const fadeIn = keyframes`
 const Container = styled.div`
   display: flex;
   flex-direction: column;
+  align-items: center;
   padding: 15px 55px;
 `
 
@@ -228,7 +229,7 @@ const Home = props => (
         <h1>Thomas Fire Help</h1>
       </MobileHeaderContainer>
       <MobileSubheadingContainer>
-        <h3> We're grassroots volunteers connecting help with need to recover from the Thomas Fire. Our community-sourced listings include: Housing, Supplies, Clothing, Volunteers, Animal Needs, Free Food, and Services.</h3>
+        <h3> We're grassroots volunteers connecting help with need to recover from the Thomas Fire. Our community-sourced listings include: Housing, Services, Free Food, Animal Needs, Supplies, Clothing and Volunteers</h3>
       </MobileSubheadingContainer>
       <MobileNavContainer>
         <StyledLink to="/looking_for_resources">
@@ -270,7 +271,7 @@ const Home = props => (
       </HeaderContainer>
       <SubheadingContainer>
         <h3>We're grassroots volunteers connecting help with need to recover from the Thomas Fire.</h3>
-        <h3>Our community-sourced listings include: Housing, Supplies, Clothing, Volunteers, Animal Needs, Free Food, and Services.</h3>
+        <h3>Our community-sourced listings include: Housing, Services, Free Food, Animal Needs, Supplies, Clothing and Volunteers</h3>
       </SubheadingContainer>
       <NavContainer>
         <StyledLink to="/looking_for_resources">

--- a/src/screens/helping/index.jsx
+++ b/src/screens/helping/index.jsx
@@ -47,7 +47,7 @@ const Home = ({ history: { goBack }}) => (
           target="_blank"
         >
           <h2> 👕 Donate or Deliver Supplies </h2>
-          <p> Donate or deliver collected supplies to registered drop-off locations. </p>
+          <p> View a list of locations where you can drop-off supplies.</p>
         </MobileExternal>
 
         <MobileExternal
@@ -107,7 +107,7 @@ const Home = ({ history: { goBack }}) => (
           target="_blank"
         >
           <h2> 👕 Donate or Deliver Supplies </h2>
-          <p> Donate or deliver collected supplies to registered drop-off locations. </p>
+          <p> View a list of locations where you can drop-off supplies. </p>
         </External>
 
         <External


### PR DESCRIPTION
## Changes

1. Change top button to "View Recovery Resources"
2. Wordsmith subheading to 1 line, move below nav buttons

## Reasoning

Provide a small "About Us" on home page so users know who we are

## Testing

Responsive Design Mode in Chrome

## Screenshots

![localhost_3000_ iphone x 2](https://user-images.githubusercontent.com/29298942/34054076-328d26da-e17e-11e7-9e0f-27512c138c89.png)
![localhost_3000_ 3](https://user-images.githubusercontent.com/29298942/34054077-32a7046a-e17e-11e7-9610-136dacbece6b.png)
